### PR TITLE
[Orgs JSON] Fix 36th LD Dems Twitter Alias

### DIFF
--- a/orgs.json
+++ b/orgs.json
@@ -25,7 +25,7 @@
     "orgWeb": "http://www.36th.org/",
     "orgFbPage": "https://www.facebook.com/36thdems/",
     "orgFbGroup": "https://www.facebook.com/groups/103518050462/",
-    "orgTwAlias": "36th Dems",
+    "orgTwAlias": "36th",
     "orgOfficers": "http://36th.org/executive-board/",
     "orgEndorsements2016": "http://36th.org/endorsements/"
   },


### PR DESCRIPTION
Was listed as "36th Dems", checked and updated to just "36th"
