### PR TITLE
[ReadMe] Add link to the Orgs spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ The purpose of this repository is to compile and public data related to the Wash
 
 ## Organizations
 One of the first projects has been to list the local (county and legislative district) Democratic party organizations and their online presence on the web, social media, etc.  
-  * A JSON file listing the URLs for local Democratic party organizations is at: http://washdems-public.github.io/Data/orgs.json
-  * A simple HTML page rendering this JSON file is at: https://washdems-public.github.io/Data/orgs.html
+  * DATA - A JSON file listing the URLs for local Democratic party organizations is at: http://washdems-public.github.io/Data/orgs.json
+  * VIEWER - A simple HTML page rendering this data file is at: https://washdems-public.github.io/Data/orgs.html
+  * SPEC - A description of the fields in the data file is at: https://github.com/WashDems-Public/Data/blob/gh-pages/orgs-spec.md
 
 ## Contributing to the orgs.json file
 Please submit a "pull request" on the JSON file to add to it:


### PR DESCRIPTION
Adds a hyperlink to the Orgs spec in the ReadMe file
